### PR TITLE
Do not run update script on repository forks

### DIFF
--- a/.github/workflows/update-actions.yml
+++ b/.github/workflows/update-actions.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   update-actions:
+    if: ${{ github.repository == 'AlexMan123456/github-actions' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0


### PR DESCRIPTION
The update script should only ever run on the main version of the repository, and never on forks. I think forks should be able to synchronise their versions with my repository when I make updates anyway, so there's no real reason they should be able to run this script.