### PR TITLE
Allow the action to pass if the tag already exists

### DIFF
--- a/.github/workflows/tag-commit.yml
+++ b/.github/workflows/tag-commit.yml
@@ -30,5 +30,10 @@ jobs:
 
       - name: Create Git tag
         run: |
-          git tag ${{ steps.get_version.outputs.version }}
-          git push origin ${{ steps.get_version.outputs.version }}
+          TAG=${{ steps.get_version.outputs.version }}
+          if git rev-parse "$TAG" >/dev/null 2>&1; then
+            echo "Tag $TAG already exists, skipping"
+          else
+            git tag "$TAG"
+            git push origin "$TAG"
+          fi


### PR DESCRIPTION
It's similar to doing || true in the npm-registry-publish workflow, except this is more explicit.