### PR TITLE
Add persist-credentials: true to publish and NPM version check

### DIFF
--- a/.github/workflows/npm-registry-publish.yml
+++ b/.github/workflows/npm-registry-publish.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Checkout the repository
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
-          persist-credentials: false
+          persist-credentials: true
 
       - name: Fetch from main
         run: git fetch --unshallow origin main

--- a/.github/workflows/npm-registry-version-check.yml
+++ b/.github/workflows/npm-registry-version-check.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Checkout the repository
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
-          persist-credentials: false
+          persist-credentials: true
 
       - name: Fetch from main
         run: git fetch --unshallow origin main


### PR DESCRIPTION
I think that might be why publish is failing. I think it needs to persist credentials in order for trusted publishing to work.