### PR TITLE
Fix commit message and create a pull request instead of force-push to…

### DIFF
--- a/.github/workflows/commit-version-change.yml
+++ b/.github/workflows/commit-version-change.yml
@@ -55,7 +55,18 @@ jobs:
       - name: Change version
         env:
           MESSAGE: ${{ inputs.message }}
-        run: pnpm version ${{ inputs.version-type }} -m "Change version number to v%s\n\n$MESSAGE"
+        run: |
+          pnpm version ${{ inputs.version-type }} -m "$(cat <<EOF
+          Change version number to v%s
 
-      - name: Push to main
-        run: git push --force origin main
+          ${MESSAGE}
+          EOF
+          )"
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@98357b18bf14b5342f975ff684046ec3b2a07725 # v8.0.0
+        with:
+          token: ${{ secrets.PAT_GITHUB }}
+          branch: alex-up-bot/update-dependencies
+          base: main
+          title: "Change the ${{ inputs.version-type }} version"


### PR DESCRIPTION
… main

Yeah, maybe a force-push to main is a bit too risky to automate. Probably better to create a pull request, even if it will take a little more time.