### PR TITLE
Set the URL origin for the GitHub user

### DIFF
--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -46,6 +46,7 @@ jobs:
         run: |
           git config --global user.name "AlexUpBot"
           git config --global user.email "alexupbot@bot.com"
+          git remote set-url origin https://x-access-token:$PAT_GITHUB@github.com/${GITHUB_REPOSITORY}.git
 
       - name: Install dependencies
         run: pnpm install


### PR DESCRIPTION
Apparently if you do it this way, the workflow run is more properly associated with the user you've set up. Pretty neat.