### PR TITLE
Get rid of diff generation

### DIFF
--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -62,36 +62,6 @@ jobs:
       - name: Update GitHub Actions
         run: pnpx actions-up -y
 
-      - name: Generate JavaScript dependency diff
-        id: javascript_dependency_diff
-        run: |
-          DIFF=$(git diff **/package.json)
-
-          if [ -z "$DIFF" ]; then
-            echo "diff=No dependency changes detected." >> $GITHUB_OUTPUT
-          else
-            {
-              echo "diff<<EOF"
-              echo "$DIFF"
-              echo "EOF"
-            } >> $GITHUB_OUTPUT
-          fi
-
-      - name: Generate GitHub Actions diff
-        id: github_actions_diff
-        run: |
-          DIFF=$(git diff .github/workflows/**/*.{yml,yaml} .github/actions/** || true)
-
-          if [ -z "$DIFF" ]; then
-            echo "diff=No workflow changes detected." >> $GITHUB_OUTPUT
-          else
-            {
-              echo "diff<<EOF"
-              echo "$DIFF"
-              echo "EOF"
-            } >> $GITHUB_OUTPUT
-          fi
-
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@98357b18bf14b5342f975ff684046ec3b2a07725 # v8.0.0
         with:
@@ -100,11 +70,4 @@ jobs:
           base: main
           commit-message: Update dependencies
           title: "Update dependencies"
-          body: |
-            This pull request updates this project's dependencies.
-
-            ## JavaScript Dependencies
-            ${{ steps.javascript_dependency_diff.outputs.diff }}
-
-            ## GitHub Actions
-            ${{ steps.github_actions_diff.outputs.diff }}
+          body: This pull request updates this project's dependencies. See the `files changed` tab for more information on exactly what got updated.


### PR DESCRIPTION
Given that it is very fiddly and GitHub Actions really annoys me, I think it's probably just better to say in the pull request body that we can access the exact updates from the files changed tab.