### PR TITLE
Fix the release note information

### DIFF
--- a/docs/releases/minor/v2.12.0.md
+++ b/docs/releases/minor/v2.12.0.md
@@ -1,6 +1,6 @@
-# v3.8.0 (Minor Release)
+# v2.12.0 (Minor Release)
 
-**Status**: In progress
+**Status**: Released
 
 This is a new minor release of the `AlexMan123456/github-actions` package. It introduces new features in a backwards-compatible way that should require very little refactoring, if any. Please read below the description of changes.
 


### PR DESCRIPTION
The version number was incorrect so has been changed. I have also prematurely set the status to released, as it is about to be released.

# Documentation Change

This is a change to the documentation of `AlexMan123456/github-actions`. It changes the way that information about the package is presented to users.

Please see the commits tab of this pull request for the description of changes.
