### PR TITLE
Change version number to v2.12.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "github-actions",
-  "version": "2.12.0",
+  "version": "2.12.1",
   "description": "Common GitHub Actions used across my repositories",
   "homepage": "https://github.com/AlexMan123456/github-actions#readme",
   "repository": {


### PR DESCRIPTION
# v2.12.1 (Patch release)

**Status**: Released

This is a new patch release of the `AlexMan123456/github-actions` package. It fixes issues with the package in a way that should require no refactoring. Please read below the description of changes.

## Description of Changes

- Get rid of a redundant step in the `commit-version-change` workflow.
    - The `Determine if a release note exists` is not required as the `Create pull request` step already errors if the release note does not exist.

