### PR TITLE
Change version number to v2.14.0

### DIFF
--- a/docs/releases/minor/v2.14.0.md
+++ b/docs/releases/minor/v2.14.0.md
@@ -1,6 +1,6 @@
 # v2.14.0 (Minor Release)
 
-**Status**: In progress
+**Status**: Released
 
 This is a new minor release of the `github-actions` package. It introduces new features in a backwards-compatible way that should require very little refactoring, if any. Please read below the description of changes.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "github-actions",
-  "version": "2.13.0",
+  "version": "2.14.0",
   "description": "Common GitHub Actions used across my repositories",
   "homepage": "https://github.com/AlexMan123456/github-actions#readme",
   "repository": {


### PR DESCRIPTION
# v2.14.0 (Minor Release)

**Status**: Released

This is a new minor release of the `github-actions` package. It introduces new features in a backwards-compatible way that should require very little refactoring, if any. Please read below the description of changes.

## Description of Changes

- Adds a step in `commit-version-change` to automatically change the status to Released
- This gets rid of the need to do this in a separate pull request, and just gets rid of the need to ever need to manually change the status at all.
- This helps to prevent the release document from getting out-of-sync with reality, where an published version may still have a status of `In progress`, or an unpublished version may have a status of `Released`.
