### PR TITLE
Change version number to v3.0.0

### DIFF
--- a/docs/releases/major/v3.0.0.md
+++ b/docs/releases/major/v3.0.0.md
@@ -1,6 +1,6 @@
 # v3.0.0 (Major Release)
 
-**Status**: In progress
+**Status**: Released
 
 This is a new major release of the `github-actions` package. It has the potential to introduce breaking changes that may require a large amount of refactoring. Please read the below description of changes and migration notes for more information.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "github-actions",
-  "version": "2.14.0",
+  "version": "3.0.0",
   "description": "Common GitHub Actions used across my repositories",
   "homepage": "https://github.com/AlexMan123456/github-actions#readme",
   "repository": {


### PR DESCRIPTION
# v3.0.0 (Major Release)

**Status**: Released

This is a new major release of the `github-actions` package. It has the potential to introduce breaking changes that may require a large amount of refactoring. Please read the below description of changes and migration notes for more information.

## Description of Changes

- This changes the `commit-version-change` workflow in a way such that it may require some refactoring on the user's part to ensure that it's compatible with the new automated version.
- It will run three times (in parallel), checking major, minor, and patch increments of the current `package.json` version, to check for if we should increment the version number based on if the release document is there for it or not.
- It will skip the pull request creation if there is a lack of release document in the expected directory, but it will create a pull request if there is.

## Migration Notes

- In your own repositories, you will need to change the `on` condition from this:

```yml
on:
  workflow_dispatch:
    inputs:
      version-type:
        description: The version type to change
        required: true
        type: choice
        options:
          - major
          - minor
          - patch
        default: patch
      message:
        description: Release message
        required: false
```

to this:

```yml
on:
  push:
    branches: ["main"]
```

This ensures that the workflow triggers on push to main and doesn't mislead you with a workflow_dispatch with options that never gets used.

## Additional Notes

- This is more optimal to me as it automatically checks for any valid release document and creates commits for them so that you don't need to do it manually and keep remembering exactly what the version type was every time so you can trigger the right dispatch.
- I feel like any time a `workflow_dispatch` is a required step in a process, it's usually a sign that there's room for optimisation somewhere, and this may be proof of that.
