### PR TITLE
Get rid of duplicate release doc check

### DIFF
--- a/.github/workflows/_commit-version-change.yml
+++ b/.github/workflows/_commit-version-change.yml
@@ -123,15 +123,6 @@ jobs:
           VERSION=v$(jq -r ".version" package.json)
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
-      - name: Check for release document
-        run: |
-          if cat "$RELEASE_DOC_PATH" >/dev/null 2>&1; then
-            echo "Release document found. Continuing..."
-          else
-            echo "No release document found. Please create a release document in $RELEASE_DOC_PATH and run the workflow again."
-            exit 1
-          fi
-
       - name: Install alex-c-line
         run: npm install -g alex-c-line@latest
 


### PR DESCRIPTION
The second workflow won't run if the document is missing anyway, so no need to check twice.

# Refactor

This is a change to the code layout of `AlexMan123456/github-actions`. It changes how the code is presented in terms of quality and structure without changing its overall runtime behaviour or user-facing functionality.

Please see the commits tab of this pull request for the description of changes.
