### PR TITLE
Change version number to v3.0.1

### DIFF
--- a/docs/releases/patch/v3.0.1.md
+++ b/docs/releases/patch/v3.0.1.md
@@ -1,6 +1,6 @@
 # v3.0.1 (Patch Release)
 
-**Status**: In progress
+**Status**: Released
 
 This is a new patch release of the `github-actions` package. It fixes issues with the package in a way that should require no refactoring. Please read below the description of changes.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "github-actions",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Common GitHub Actions used across my repositories",
   "homepage": "https://github.com/AlexMan123456/github-actions#readme",
   "repository": {


### PR DESCRIPTION
# v3.0.1 (Patch Release)

**Status**: Released

This is a new patch release of the `github-actions` package. It fixes issues with the package in a way that should require no refactoring. Please read below the description of changes.

## Description of Changes

- Changes the pull request author to be the bot user.
    - I think the pull request composite action I'm currently using defaults to me generally, even though I do have a step to set up the GitHub bot user.
    - As such, I need to set the commit author in the pull request action inputs directly so that AlexUpBot's information is what get used rather than my own GitHub details.
