### PR TITLE
Change version number to v3.0.2

### DIFF
--- a/docs/releases/patch/v3.0.2.md
+++ b/docs/releases/patch/v3.0.2.md
@@ -1,6 +1,6 @@
 # v3.0.2 (Patch Release)
 
-**Status**: In progress
+**Status**: Released
 
 This is a new patch release of the `github-actions` package. It fixes issues with the package in a way that should require no refactoring. Please read below the description of changes.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "github-actions",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "Common GitHub Actions used across my repositories",
   "homepage": "https://github.com/AlexMan123456/github-actions#readme",
   "repository": {


### PR DESCRIPTION
# v3.0.2 (Patch Release)

**Status**: Released

This is a new patch release of the `github-actions` package. It fixes issues with the package in a way that should require no refactoring. Please read below the description of changes.

## Description of Changes

- Removed the step to use PNPM in commit-version-change
    - I was never really using PNPM in this workflow, and I think it was that step that was creating weird flaky behaviour with Use Node.js because of the caching. Given that there's no real benefit of using PNPM in that workflow, I've removed the step to set it up there entirely.
