### PR TITLE
Change version number to v3.0.3

### DIFF
--- a/docs/releases/patch/v3.0.3.md
+++ b/docs/releases/patch/v3.0.3.md
@@ -1,6 +1,6 @@
 # v3.0.3 (Patch Release)
 
-**Status**: In progress
+**Status**: Released
 
 This is a new patch release of the `github-actions` package. It fixes issues with the package in a way that should require no refactoring. Please read below the description of changes.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "github-actions",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "description": "Common GitHub Actions used across my repositories",
   "homepage": "https://github.com/AlexMan123456/github-actions#readme",
   "repository": {


### PR DESCRIPTION
# v3.0.3 (Patch Release)

**Status**: Released

This is a new patch release of the `github-actions` package. It fixes issues with the package in a way that should require no refactoring. Please read below the description of changes.

## Description of Changes

- This just gets rid of `git fetch --unshallow origin main` in most workflows, as it is no longer necessary.
- The motivation for including this is no longer present in the new versioning/docs pattern I have recently stabilised, so I think it should be safe to remove.
