### PR TITLE
Change version number to v3.0.4

### DIFF
--- a/docs/releases/patch/v3.0.4.md
+++ b/docs/releases/patch/v3.0.4.md
@@ -1,6 +1,6 @@
 # v3.0.4 (Patch Release)
 
-**Status**: In progress
+**Status**: Released
 
 This is a new patch release of the `github-actions` package. It fixes issues with the package in a way that should require no refactoring. Please read below the description of changes.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "github-actions",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "description": "Common GitHub Actions used across my repositories",
   "homepage": "https://github.com/AlexMan123456/github-actions#readme",
   "repository": {


### PR DESCRIPTION
# v3.0.4 (Patch Release)

**Status**: Released

This is a new patch release of the `github-actions` package. It fixes issues with the package in a way that should require no refactoring. Please read below the description of changes.

## Description of Changes

- Explicitly install `actions-up` in `update-dependencies` workflow
    - I generally prefer to have a step that explicitly installs global dependencies in actions rather than relying on npx or pnpx nowadays, as npx or pnpx always comes with that warning beforehand, which causes extra noise in the logs.
- After installing any global dependencies at latest, show the version that got installed.
    - This just makes it easier to inspect the workflow if anything goes wrong, as we can use that to monitor exactly what versions are being used in the workflows.

