### PR TITLE
Change version number to v3.1.1

### DIFF
--- a/docs/releases/patch/v3.1.1.md
+++ b/docs/releases/patch/v3.1.1.md
@@ -1,6 +1,6 @@
 # v3.1.1 (Patch Release)
 
-**Status**: In progress
+**Status**: Released
 
 This is a new patch release of the `github-actions` package. It fixes issues with the package in a way that should require no refactoring. Please read below the description of changes.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "github-actions",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "Common GitHub Actions used across my repositories",
   "homepage": "https://github.com/AlexMan123456/github-actions#readme",
   "repository": {


### PR DESCRIPTION
# v3.1.1 (Patch Release)

**Status**: Released

This is a new patch release of the `github-actions` package. It fixes issues with the package in a way that should require no refactoring. Please read below the description of changes.

## Description of Changes

- Forgot to allow `create-feature-docs` to take a `PAT_GITHUB` secret so it can create the pull request to re-generate the docs...
- Whoops!
