### PR TITLE
Add a full stop in description field

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "github-actions",
   "version": "3.1.2",
-  "description": "Common GitHub Actions used across my repositories",
+  "description": "Common GitHub Actions used across my repositories.",
   "homepage": "https://github.com/AlexMan123456/github-actions#readme",
   "repository": {
     "type": "git",


### PR DESCRIPTION
I am pedantic.

# Documentation Change

This is a change to the documentation of `AlexMan123456/github-actions`. It changes the way that information about the package is presented to users.

Please see the commits tab of this pull request for the description of changes.
