### PR TITLE
Change version number to v3.2.0

### DIFF
--- a/docs/releases/minor/v3.2.0.md
+++ b/docs/releases/minor/v3.2.0.md
@@ -1,6 +1,6 @@
 # v3.2.0 (Minor Release)
 
-**Status**: In progress
+**Status**: Released
 
 This is a new minor release of the `github-actions` package. It introduces new features in a backwards-compatible way that should require very little refactoring, if any. Please read below the description of changes.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "github-actions",
-  "version": "3.1.2",
+  "version": "3.2.0",
   "description": "Common GitHub Actions used across my repositories.",
   "homepage": "https://github.com/AlexMan123456/github-actions#readme",
   "repository": {


### PR DESCRIPTION
# v3.2.0 (Minor Release)

**Status**: Released

This is a new minor release of the `github-actions` package. It introduces new features in a backwards-compatible way that should require very little refactoring, if any. Please read below the description of changes.

## Description of Changes

- Adds a step to `tag-commit` workflow to create a GitHub Release when tagging the latest commit with the most recent package.json version.
    - This allows the release information to be more central in the repository itself, rather than requiring people to dig through `docs/features` every time to find the note manually.

## Additional Notes

- This will require all my existing NPM package repositories to add the `tag-commit` workflow to their repositories as well. I initially didn't do this as versioning in NPM packages is managed by NPM, but if we want those to also make use of GitHub Releases, we need this workflow present there as well so that we also tag their commits and create releases there too.
- Note that this will NOT go through and turn all existing release notes into GitHub Releases for us. It will only consider whatever the most recently added feature after the workflow gets added was to be a new release. I am not sure if it would be worth it to create a throwaway action that migrates all existing documents to be releases, especially considering how annoying it is to debug actions since it's hard to test them locally (if not impossible).
