### PR TITLE
Revert "Change version number to v4.0.0"

### DIFF
--- a/docs/releases/major/v4.0.0.md
+++ b/docs/releases/major/v4.0.0.md
@@ -1,6 +1,6 @@
 # v4.0.0 (Major Release)
 
-**Status**: Released
+**Status**: In progress
 
 This is a new major release of the `github-actions` package. It has the potential to introduce breaking changes that may require a large amount of refactoring. Please read the below description of changes and migration notes for more information.
 


### PR DESCRIPTION
This reverts commit 99c14cf04d8ab1d10baabd02af4ef119726e095b.

# Bug Fix

This is a bug fix for `github-actions`. It fixes an unintended side-effect of the package.

Please see the commits tab of this pull request for the description of changes.
