### PR TITLE
Change version number to v4.0.1

### DIFF
--- a/docs/releases/patch/v4.0.1.md
+++ b/docs/releases/patch/v4.0.1.md
@@ -1,6 +1,6 @@
 # v4.0.1 (Patch Release)
 
-**Status**: In progress
+**Status**: Released
 
 This is a new patch release of the `github-actions` package. It fixes issues with the package in a way that should require no refactoring. Please read below the description of changes.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "github-actions",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "Common GitHub Actions used across my repositories.",
   "homepage": "https://github.com/AlexMan123456/github-actions#readme",
   "repository": {


### PR DESCRIPTION
# v4.0.1 (Patch Release)

**Status**: Released

This is a new patch release of the `github-actions` package. It fixes issues with the package in a way that should require no refactoring. Please read below the description of changes.

## Description of Changes

- Allow `create-github-release` to be triggered on workflow call
    - I forgot to add this so my utility package was unable to use this...

## Additional Notes

- Whoops...
