### PR TITLE
Change version number to v4.0.2

### DIFF
--- a/docs/releases/patch/v4.0.2.md
+++ b/docs/releases/patch/v4.0.2.md
@@ -1,6 +1,6 @@
 # v4.0.2 (Patch Release)
 
-**Status**: In progress
+**Status**: Released
 
 This is a new patch release of the `github-actions` package. It fixes issues with the package in a way that should require no refactoring. Please read below the description of changes.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "github-actions",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "description": "Common GitHub Actions used across my repositories.",
   "homepage": "https://github.com/AlexMan123456/github-actions#readme",
   "repository": {


### PR DESCRIPTION
# v4.0.2 (Patch Release)

**Status**: Released

This is a new patch release of the `github-actions` package. It fixes issues with the package in a way that should require no refactoring. Please read below the description of changes.

## Description of Changes

- OH MY GOD I HATE GITHUB ACTIONS!
- I'm meant to allow `create-github-release` to take the GitHub token secret on workflow_call as well so that it can use my GitHub token to create the release as well...

## Additional Notes

- It's especially annoying now because now I also have to document all these patch releases while I debug the integration live in production with utility! You all get to see how especially frustrating this annoying as heck process of debugging a GitHub Action looks like, all through these very cursed patch release documents for these very cursed patch releases that should really have just been a single major release but can't be because GOD F***ING FORBID we give developers a nice way to test their Goddamn actions locally, right?!
- Ugh!
