### PR TITLE
Change version number to v4.0.3

### DIFF
--- a/docs/releases/patch/v4.0.3.md
+++ b/docs/releases/patch/v4.0.3.md
@@ -1,6 +1,6 @@
 # v4.0.3 (Patch Release)
 
-**Status**: In progress
+**Status**: Released
 
 This is a new patch release of the `github-actions` package. It fixes issues with the package in a way that should require no refactoring. Please read below the description of changes.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "github-actions",
-  "version": "4.0.2",
+  "version": "4.0.3",
   "description": "Common GitHub Actions used across my repositories.",
   "homepage": "https://github.com/AlexMan123456/github-actions#readme",
   "repository": {


### PR DESCRIPTION
# v4.0.3 (Patch Release)

**Status**: Released

This is a new patch release of the `github-actions` package. It fixes issues with the package in a way that should require no refactoring. Please read below the description of changes.

## Description of Changes

- So... what the f***?
- Someone please tell me why `./.github` behaves differently depending on if it's trying to call a reusable workflow or a composite action!
- Yeah, so, get this, everyone... if you see a path like `./.github/workflows/_commit-version-change.yml` in reusable workflow `A` in this repository, and we call reusable workflow `A` in repository `B`, where do you think it'd take you?
    - If you guessed "To the `_commit-version-change.yml` workflow in **this** repository (not repository `B`), congratulations! You'd be absolutely correct. And that is more or less the sane thing to do (minus the `./` convention, but my God, we will get there!)
- But now, what happens if try to do `./.github/actions/commit-changes` in reusable workflow `A` in this repository, and we call it from repository `B`?
    - If you thought it'd behave the same way, where it calls the `commit-changes` composite action from **this** repository, congratulations, you win nothing this time!
    - No, for some ridiculous reason, it calls the composite action from the `.github/actions` directory from repository **B** for some absolutely cursed reason!!!!!!!!
- The fix for the above is to treat that action as an external action, and reference the version on origin, with the latest tag (or SHA) from origin. That is, we now have to put `AlexMan123456/.github/actions/commit-changes@<sha> # vX.Y.Z` in the `uses` instead of the local directory to ensure consistent results in this repository and repository `B`. The `update-dependencies` workflow was failing because of this in utility.

## Additional Notes

- If that feels cursed, that's because it absolutely is and I absolutely hate this with every ounce of my being!
- Like... the package can theoretically be out-of-date with itself now???? Who designed this stupid system?!
- The fix is about as cursed as trying to install, say `@alextheman/utility` from within my utility package, except here this is actually the fix somehow!
- I don't know why we have this inconsistent behaviour anyway. The `./.github/workflows` behaviour is definitely the more sane one - why is that not used with actions? If the whole point of reusable workflows is to abstract away behaviour so that users don't need to know the exact code behind the action and they don't need as much extra setup, why make it implicitly reliant on the consuming repository's state?
- If it behaved consistently, I'd at least tolerate it a bit more, but having DIFFERENT behaviours for whether you're referencing `./.github/workflows` or `./.github/actions`? I'm sorry - that's just unacceptable.
- Don't even get me started on how they ruined `./`! Usually that means 'start from the directory of the current file'. But not in GitHub Actions, it doesn't! Here it means 'start from the project root', for some reason! That shouldn't be the case, though - project root **should** be implied by no prefix at all (e.g. `.github/workflows`)!
- Again, I'd be ok with this if it was consistent, but it's just not. It's an absolute mess of a system which just makes debugging this repository so much more annoying!
- This is going beyond just 'oh I have to debug on main now' - this is a fundamental design flaw with GitHub Actions that just makes it so much worse to debug. Even Infrastructure is less frustrating because at least there, even if you have to debug on main, Terraform usually plays nicely with its CLI allowing you to make quick edits and imports and stuff. But here we have inconsistent behaviour across things that feel like they should be the same, but aren't for whatever reason.
- ...so yeah, in case you couldn't tell, I have... just a bit of a hatred for GitHub Actions at times!
