### PR TITLE
Change version number to v4.0.4

### DIFF
--- a/docs/releases/patch/v4.0.4.md
+++ b/docs/releases/patch/v4.0.4.md
@@ -1,6 +1,6 @@
 # v4.0.4 (Patch Release)
 
-**Status**: In progress
+**Status**: Released
 
 This is a new patch release of the `github-actions` package. It fixes issues with the package in a way that should require no refactoring. Please read below the description of changes.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "github-actions",
-  "version": "4.0.3",
+  "version": "4.0.4",
   "description": "Common GitHub Actions used across my repositories.",
   "homepage": "https://github.com/AlexMan123456/github-actions#readme",
   "repository": {


### PR DESCRIPTION
# v4.0.4 (Patch Release)

**Status**: Released

This is a new patch release of the `github-actions` package. It fixes issues with the package in a way that should require no refactoring. Please read below the description of changes.

## Description of Changes

- Ensure release creation can only happen if the release document is present

## Additional Notes

- This follows from an oversight found in components where it created a release despite the document not existing. This changes it so that it cannot create a release if a document does not exist.
