### PR TITLE
Change version number to v4.0.5

### DIFF
--- a/docs/releases/patch/v4.0.5.md
+++ b/docs/releases/patch/v4.0.5.md
@@ -1,6 +1,6 @@
 # v4.0.5 (Patch Release)
 
-**Status**: In progress
+**Status**: Released
 
 This is a new patch release of the `github-actions` package. It fixes issues with the package in a way that should require no refactoring. Please read below the description of changes.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "github-actions",
-  "version": "4.0.4",
+  "version": "4.0.5",
   "description": "Common GitHub Actions used across my repositories.",
   "homepage": "https://github.com/AlexMan123456/github-actions#readme",
   "repository": {


### PR DESCRIPTION
# v4.0.5 (Patch Release)

**Status**: Released

This is a new patch release of the `github-actions` package. It fixes issues with the package in a way that should require no refactoring. Please read below the description of changes.

## Description of Changes

- Adds an output to `npm-registry-publish` to determine if the package published successfully or not.
    - This will be helpful in the NPM package repositories to ensure that a GitHub release does not get created if the publish to NPM did not happen.
