### PR TITLE
Update release note v4.0.6

### DIFF
--- a/docs/releases/patch/v4.0.6.md
+++ b/docs/releases/patch/v4.0.6.md
@@ -7,8 +7,5 @@ This is a new patch release of the `github-actions` package. It fixes issues wit
 ## Description of Changes
 
 - Add a step to `update-dependencies` that checks for existence of Terraform files, and if found, set up Terraform before updating.
-    - This is needed in the Infrastructure repository to ensure that 
-
-## Additional Notes
-
-Additional notes here
+    - This is needed in the Infrastructure repository to ensure that the action also targets Terraform providers as well.
+    - This should not affect other repositories, though, as they don't use Terraform and Terraform updates are skipped in non-Terraform repositories.


### PR DESCRIPTION
# Documentation Change

This is a change to the documentation of `github-actions`. It changes the way that information about the package is presented to users.

Please see the commits tab of this pull request for the description of changes.
