### PR TITLE
Change version number to v4.1.0

### DIFF
--- a/docs/releases/minor/v4.1.0.md
+++ b/docs/releases/minor/v4.1.0.md
@@ -1,6 +1,6 @@
 # v4.1.0 (Minor Release)
 
-**Status**: In progress
+**Status**: Released
 
 This is a new minor release of the `github-actions` package. It introduces new features in a backwards-compatible way that should require very little refactoring, if any. Please read below the description of changes.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "github-actions",
-  "version": "4.0.6",
+  "version": "4.1.0",
   "description": "Common GitHub Actions used across my repositories.",
   "homepage": "https://github.com/AlexMan123456/github-actions#readme",
   "repository": {


### PR DESCRIPTION
# v4.1.0 (Minor Release)

**Status**: Released

This is a new minor release of the `github-actions` package. It introduces new features in a backwards-compatible way that should require very little refactoring, if any. Please read below the description of changes.

## Description of Changes

- Rename `actions-ci` to `self-ci`.
    - This is what this repository uses to check itself.
- Adds a new reusable `actions-ci` workflow for other repositories to use.
    - This will be used to allow other repositories to lint the actions without needing to worry about whether the user has Zizmor locally installed or not.

## Additional Notes

- Note that I will need to change Infrastructure to set `self-ci` to be the new required CI check, rather than `actions-ci` now.
