### PR TITLE
Change version number to v6.0.0

### DIFF
--- a/docs/releases/major/v6.0.0.md
+++ b/docs/releases/major/v6.0.0.md
@@ -1,6 +1,6 @@
 # v6.0.0 (Major Release)
 
-**Status**: In progress
+**Status**: Released
 
 This is a new major release of the `github-actions` package. It has the potential to introduce breaking changes that may require a large amount of refactoring. Please read the below description of changes and migration notes for more information.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "github-actions",
-  "version": "5.0.0",
+  "version": "6.0.0",
   "description": "Common GitHub Actions used across my repositories.",
   "homepage": "https://github.com/AlexMan123456/github-actions#readme",
   "repository": {


### PR DESCRIPTION
# v6.0.0 (Major Release)

**Status**: Released

This is a new major release of the `github-actions` package. It has the potential to introduce breaking changes that may require a large amount of refactoring. Please read the below description of changes and migration notes for more information.

## Description of Changes

- Rename the reusable workflow secret input from `PAT_GITHUB` to `GITHUB_ACTIONS_TOKEN`
    - This reads a lot clearer to me as it opens up the possibility of it not necessarily needing to be a personal token (for example, this may be the default GitHub-provided token or a bot token).

## Migration Notes

- Wherever you are calling a reusable workflow with 
```yml
secrets:
  PAT_GITHUB: <token>
```

use

```yml
secrets:
  GITHUB_ACTIONS_TOKEN: <token>
```

instead

## Additional Notes

- Yeah, v5 was a very short-lived major. Sorry, everyone!
- Like, v5 got v5.0.0, and now we're suddenly at v6. I was really meant to include this in v5 but forgot, hence the new major version all of a sudden.
- Again, really sorry about this, but after this, things will be more stable from here, especially now that all repositories are officially part of the new GitHub organisation.
- But also... it's GitHub Actions. When has changes to this repository ever been 100% stable? Do I need to remind you all of the tale of release note v4.0.3?
- We got close, though - I wanted `GITHUB_TOKEN` because that felt like an obvious enough name for the token, but *nooooo*, I can't have that for whatever reason, so now we have to use `GITHUB_ACTIONS_TOKEN` instead.
- You lot don't know how tempted I was to use `GUTHIB_TOKEN` instead, though, but decided against it because otherwise it'd look like I do things in this repository out of spite. Not that you'd be wrong...
