### PR TITLE
Enable merge groups

### DIFF
--- a/.github/workflows/self-ci.yml
+++ b/.github/workflows/self-ci.yml
@@ -5,6 +5,8 @@ on:
     branches: ["main"]
   pull_request:
     branches: ["main"]
+  merge_group:
+    types: [checks_requested]
 
 permissions:
   contents: read


### PR DESCRIPTION
This will make controlling merges into main a lot easier, automating the need to manually update branches as the merge group will ensure branches are merged in a consistent order.

# Tooling Change

This is a change to the tooling of `github-actions`. It changes the internal workings of the package and should have no noticeable effect on users.

Please see the commits tab of this pull request for the description of changes.
