### PR TITLE
Use the GITHUB_TOKEN with the actions-up updates

### DIFF
--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -48,6 +48,13 @@ jobs:
           corepack enable
           corepack --version
 
+      - name: Mint GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
+        with:
+          app-id: ${{ github.repository == 'alextheman231/github-actions' && secrets.ALEX_UP_BOT_APP_ID || secrets.APP_ID }}
+          private-key: ${{ github.repository == 'alextheman231/github-actions' && secrets.ALEX_UP_BOT_PRIVATE_KEY || secrets.APP_PRIVATE_KEY }}
+
       - name: Setup GitHub user
         run: |
           git config --global user.name "alex-up-bot"
@@ -92,6 +99,8 @@ jobs:
           message: "Update JavaScript dependencies"
 
       - name: Update GitHub Actions
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         run: actions-up -y
 
       - name: Commit GitHub Actions updates
@@ -131,13 +140,6 @@ jobs:
             echo "Template: tooling_change"
             echo "body_path=.github/PULL_REQUEST_TEMPLATE/tooling_change.md" >> "$GITHUB_OUTPUT"
           fi
-
-      - name: Mint GitHub App token
-        id: app-token
-        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
-        with:
-          app-id: ${{ github.repository == 'alextheman231/github-actions' && secrets.ALEX_UP_BOT_APP_ID || secrets.APP_ID }}
-          private-key: ${{ github.repository == 'alextheman231/github-actions' && secrets.ALEX_UP_BOT_PRIVATE_KEY || secrets.APP_PRIVATE_KEY }}
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@98357b18bf14b5342f975ff684046ec3b2a07725 # v8.0.0


### PR DESCRIPTION
This seems to fix a potential flaky error we get sometimes where we get rate-limited without this.

# Tooling Change

This is a change to the tooling of `github-actions`. It changes the internal workings of the package and should have no noticeable effect on users.

Please see the commits tab of this pull request for the description of changes.
