### PR TITLE
Get rid of redundant author and committer

### DIFF
--- a/.github/workflows/_commit-version-change.yml
+++ b/.github/workflows/_commit-version-change.yml
@@ -131,8 +131,6 @@ jobs:
         uses: peter-evans/create-pull-request@98357b18bf14b5342f975ff684046ec3b2a07725 # v8.0.0
         with:
           token: ${{ steps.app-token.outputs.token }}
-          author: alex-up-bot <alexupbot@bot.com>
-          committer: alex-up-bot <alexupbot@bot.com>
           branch: alex-up-bot/change-${{ env.VERSION_TYPE }}-version
           base: main
           commit-message: "Change version number to ${{ steps.get_new_version.outputs.version }}"

--- a/.github/workflows/create-feature-docs.yml
+++ b/.github/workflows/create-feature-docs.yml
@@ -59,8 +59,6 @@ jobs:
         uses: peter-evans/create-pull-request@98357b18bf14b5342f975ff684046ec3b2a07725 # v8.0.0
         with:
           token: ${{ steps.app-token.outputs.token }}
-          author: alex-up-bot <alexupbot@bot.com>
-          committer: alex-up-bot <alexupbot@bot.com>
           branch: alex-up-bot/create-feature-docs
           base: main
           commit-message: Create feature docs

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -145,8 +145,6 @@ jobs:
         uses: peter-evans/create-pull-request@98357b18bf14b5342f975ff684046ec3b2a07725 # v8.0.0
         with:
           token: ${{ steps.app-token.outputs.token }}
-          author: alex-up-bot <alexupbot@bot.com>
-          committer: alex-up-bot <alexupbot@bot.com>
           branch: alex-up-bot/update-dependencies
           base: main
           title: "Update dependencies"


### PR DESCRIPTION
Probably not needed as I think it gets it from the token now.

# Refactor

This is a change to the code layout of `github-actions`. It changes how the code is presented in terms of quality and structure without changing its overall runtime behaviour or user-facing functionality.

Please see the commits tab of this pull request for the description of changes.
