### PR TITLE
Compute whether or not Terraform is used once in one step, then reuse…

### DIFF
--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -26,6 +26,18 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Check for Terraform files
+        id: check-terraform
+        shell: bash
+        run: |
+          shopt -s globstar nullglob
+          files=( **/*.tf )
+          if (( ${#files[@]} > 0 )); then
+            echo "has_terraform=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_terraform=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Use PNPM
         uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
         with:
@@ -38,7 +50,7 @@ jobs:
           cache: "pnpm"
 
       - name: Setup Terraform
-        if: ${{ hashFiles('**/*.tf') != '' }}
+        if: ${{ steps.check-terraform.outputs.has_terraform == 'true' }}
         uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
         with:
           terraform_version: 1.14.3
@@ -110,12 +122,12 @@ jobs:
           message: "Update GitHub Actions"
 
       - name: Update Terraform Providers
-        if: ${{ hashFiles('**/*.tf') != '' }}
+        if: ${{ steps.check-terraform.outputs.has_terraform == 'true' }}
         run: terraform init -upgrade -backend=false
 
       - name: Commit Terraform updates
-        if: ${{ hashFiles('**/*.tf') != '' }}
-        uses: alextheman231/github-actions/.github/actions/commit-changes@f00ea95a57c8d8e9810149d2b5c5dca1af7d8058 # v6.0.0
+        if: ${{ steps.check-terraform.outputs.has_terraform == 'true' }}
+        uses: alextheman231/github-actions/.github/actions/commit-changes@d94b65a56e0f50cbbd674bc019f732bd606d7063 # v5.0.0
         id: commit_terraform_updates
         with:
           message: "Update Terraform Providers"


### PR DESCRIPTION
… the result

This should make the workflow feel a little faster as it doesn't have to compute the hash three times in a row.

# Tooling Change

This is a change to the tooling of `github-actions`. It changes the internal workings of the package and should have no noticeable effect on users.

Please see the commits tab of this pull request for the description of changes.
