### PR TITLE
Add a release note for v7.0.1

### DIFF
--- a/docs/releases/patch/v7.0.1.md
+++ b/docs/releases/patch/v7.0.1.md
@@ -1,0 +1,13 @@
+# v7.0.1 (Patch Release)
+
+**Status**: In progress
+
+This is a new patch release of the `github-actions` package. It fixes issues with the package in a way that should require no refactoring. Please read below the description of changes.
+
+## Description of Changes
+
+- A quick patch release to test to see if alex-up-bot will create the Git tag after the most recent ruleset addition.
+
+## Additional Notes
+
+- If successful, users won't be able to create version tags, but alex-up-bot will.


### PR DESCRIPTION
# Miscellaneous

This is a general change to `github-actions` that does not fit in any of the other provided categories.

Please see the commits tab of this pull request for the description of changes.
