### PR TITLE
Change status of v7.2.3

### DIFF
--- a/docs/releases/patch/v7.2.3.md
+++ b/docs/releases/patch/v7.2.3.md
@@ -1,6 +1,6 @@
 # v7.2.3 (Patch Release)
 
-**Status**: Released
+**Status**: In progress
 
 This is a new patch release of the `github-actions` package. It fixes issues with the package in a way that should require no refactoring. Please read below the description of changes.
 


### PR DESCRIPTION
The release note should really start with an 'In progress' status, otherwise the commit-version-change workflow doesn't allow it.