### PR TITLE
Use specifically alex-c-line v1.19.3 in actions

### DIFF
--- a/.github/workflows/_commit-version-change.yml
+++ b/.github/workflows/_commit-version-change.yml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Install alex-c-line
         run: |
-          npm install -g alex-c-line@latest
+          npm install -g alex-c-line@1.19.3
           alex-c-line --version
 
       - name: Get next version
@@ -113,7 +113,7 @@ jobs:
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
       - name: Install alex-c-line
-        run: npm install -g alex-c-line@latest
+        run: npm install -g alex-c-line@1.19.3
 
       - name: Change the status in the release document
         env:

--- a/.github/workflows/create-github-release.yml
+++ b/.github/workflows/create-github-release.yml
@@ -30,7 +30,7 @@ jobs:
           node-version: 22
 
       - name: Install alex-c-line
-        run: npm install -g alex-c-line@latest
+        run: npm install -g alex-c-line@1.19.3
 
       - name: Fetch tags from main
         run: git fetch --tags origin

--- a/.github/workflows/create-pull-request-templates.yml
+++ b/.github/workflows/create-pull-request-templates.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Install alex-c-line
         run: |
-          npm install -g alex-c-line@latest
+          npm install -g alex-c-line@1.19.3
           alex-c-line --version
 
       - name: Install dependencies

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -75,11 +75,10 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
-      - name: Install actions-up and alex-c-line
+      - name: Install actions-up
         run: |
-          npm install -g actions-up@latest alex-c-line@latest
+          npm install -g actions-up@latest
           actions-up --version
-          alex-c-line --version
 
       - name: Update PNPM
         run: corepack use pnpm@latest


### PR DESCRIPTION
Any future release of alex-c-line will most likely break a lot of these actions due to the new release note directory structure in alex-c-line. As such, the only way we can guarantee that the old workflows keep working is to pin them to v1.19.3

# Tooling Change

This is a change to the tooling of `github-actions`. It changes the internal workings of the package and should have no noticeable effect on users.

Please see the commits tab of this pull request for the description of changes.
