### PR TITLE
Add a release note for v7.2.6

### DIFF
--- a/docs/releases/patch/v7.2.6.md
+++ b/docs/releases/patch/v7.2.6.md
@@ -1,0 +1,17 @@
+# v7.2.6 (Patch Release)
+
+**Status**: In progress
+
+This is a new patch release of the `github-actions` package. It fixes issues with the package in a way that should require no refactoring. Please read below the description of changes.
+
+## Description of Changes
+
+- Pin `alex-c-line` to `v1.19.3`.
+    - This is being done in preparation for the upcoming release note migration that is about to happen.
+    - Because the next few updates of `alex-c-line` are going to drastically change how new release notes get added, future versions of it will break and we cannot truly guarantee that it will be stable.
+    - As such, I have decided that, for just one release, we will pin it at exactly v1.19.3, which serves as a cler snapshot of a version that I absolutely know will work and won't require us to refactor.
+
+## Additional Notes
+
+- Again, though, my workflows in this repository are being treated as internal for the most part, and while I will document for my sake and the sake of anyone contributing to the repository, they are only really expected to be used in my repositories. Usage elsewhere may potentially break, but if it does break for you, please do let me know by means of GitHub Issues.
+- That said, I can never express a full guarantee that the currently live version will always work as intended. GitHub Actions is incredibly fiddly at times, but hopefully the migration and release note pattern in general works.


### PR DESCRIPTION
# Documentation Change

This is a change to the documentation of `github-actions`. It changes the way that information about the package is presented to users.

Please see the commits tab of this pull request for the description of changes.
