### PR TITLE
Do the ugly conditional thing

### DIFF
--- a/.github/workflows/commit-version-change.yml
+++ b/.github/workflows/commit-version-change.yml
@@ -24,7 +24,7 @@ jobs:
     uses: ./.github/workflows/_commit-version-change.yml
     with:
       version-type: major
-      create-feature-docs: ${{ inputs.create-feature-docs }}
+      create-feature-docs: ${{ github.repository == 'alextheman231/github-actions' && false || inputs.create-feature-docs }}
     secrets:
       APP_ID: ${{ github.repository == 'alextheman231/github-actions' && secrets.ALEX_UP_BOT_APP_ID || secrets.APP_ID }}
       APP_PRIVATE_KEY: ${{ github.repository == 'alextheman231/github-actions' && secrets.ALEX_UP_BOT_PRIVATE_KEY || secrets.APP_PRIVATE_KEY }}
@@ -36,7 +36,7 @@ jobs:
     uses: ./.github/workflows/_commit-version-change.yml
     with:
       version-type: minor
-      create-feature-docs: ${{ inputs.create-feature-docs }}
+      create-feature-docs: ${{ github.repository == 'alextheman231/github-actions' && false || inputs.create-feature-docs }}
     secrets:
       APP_ID: ${{ github.repository == 'alextheman231/github-actions' && secrets.ALEX_UP_BOT_APP_ID || secrets.APP_ID }}
       APP_PRIVATE_KEY: ${{ github.repository == 'alextheman231/github-actions' && secrets.ALEX_UP_BOT_PRIVATE_KEY || secrets.APP_PRIVATE_KEY }}
@@ -48,7 +48,7 @@ jobs:
     uses: ./.github/workflows/_commit-version-change.yml
     with:
       version-type: patch
-      create-feature-docs: ${{ inputs.create-feature-docs }}
+      create-feature-docs: ${{ github.repository == 'alextheman231/github-actions' && false || inputs.create-feature-docs }}
     secrets:
       APP_ID: ${{ github.repository == 'alextheman231/github-actions' && secrets.ALEX_UP_BOT_APP_ID || secrets.APP_ID }}
       APP_PRIVATE_KEY: ${{ github.repository == 'alextheman231/github-actions' && secrets.ALEX_UP_BOT_PRIVATE_KEY || secrets.APP_PRIVATE_KEY }}


### PR DESCRIPTION
Because why let the reusable workflow actually be context-aware and say that if it's run in this repository, let the inputs be these specific things?

I literally even set the defaults in the inputs too - why not just... use those? Why does this entire system feel like it's been duct taped together?

# Bug Fix

This is a bug fix for `github-actions`. It fixes an unintended side-effect of the package.

Please see the commits tab of this pull request for the description of changes.
