### PR TITLE
Temporarily fix create-pull-request-template

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "type": "module",
   "main": "index.js",
   "scripts": {
-    "build": "exit 0"
+    "build": "exit 0",
     "create-release-note": "bash -c 'git pull origin main && alex-c-line create-release-note-2 $@' --",
     "format": "pnpm run format-package-json && pnpm run format-prettier && pnpm run format-zizmor",
     "format-package-json": "eslint --fix --suppress-all package.json && rm -f eslint-suppressions.json",


### PR DESCRIPTION
It tries to run a build step, but this repository does not need it. Hence, the quickest fix for now is just to introduce one anyway that just does `exit 0`, but when I have time I will adjust the action to allow it to take a run-build input.