### PR TITLE
|| true workaround

### DIFF
--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -136,7 +136,7 @@ jobs:
 
       - name: Get outdated JavaScript dependencies
         id: outdated-javascript-dependencies
-        run: pnpm outdated
+        run: pnpm outdated || true
 
       - name: Find Comment
         if: ${{ github.event_name == 'pull_request' }}


### PR DESCRIPTION
pnpm outdated fails if there are outdated dependencies, which is not ideal for CI.

# Bug Fix

This is a bug fix for `github-actions`. It fixes an unintended side-effect of the package.

Please see the commits tab of this pull request for the description of changes.
