### PR TITLE
continue-on-error if pnpm outdated errors

### DIFF
--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -136,7 +136,8 @@ jobs:
 
       - name: Get outdated JavaScript dependencies
         id: outdated-javascript-dependencies
-        run: pnpm outdated || true
+        run: pnpm outdated
+        continue-on-error: true
 
       - name: Find Comment
         uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad # v4.0.0


### PR DESCRIPTION
This ensures that if we exit with exit code 1, the action doesn't fail. This is needed to ensure that if there are outdated dependencies, we do still comment them.

# Bug Fix

This is a bug fix for `github-actions`. It fixes an unintended side-effect of the package.

Please see the commits tab of this pull request for the description of changes.
