### PR TITLE
Use stdout in pull request comment

### DIFF
--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -158,4 +158,4 @@ jobs:
           body: |
             # Outdated Dependencies
 
-            ${{ steps.outdated-javascript-dependencies.outputs.stderr }}
+            ${{ steps.outdated-javascript-dependencies.outputs.stdout }}


### PR DESCRIPTION
It does come out on stdout, I think.

# Bug Fix

This is a bug fix for `github-actions`. It fixes an unintended side-effect of the package.

Please see the commits tab of this pull request for the description of changes.
