### PR TITLE
Explicitly set the results of running pnpm outdated to GitHub output

### DIFF
--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -136,8 +136,10 @@ jobs:
 
       - name: Get outdated JavaScript dependencies
         id: outdated-javascript-dependencies
-        run: pnpm outdated
-        continue-on-error: true
+        run: |
+          OUTDATED_DEPENDENCIES=$(pnpm outdated || true)
+
+          echo "outdated_dependencies=$OUTDATED_DEPENDENCIES" >> $GITHUB_OUTPUT
 
       - name: Find Comment
         uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad # v4.0.0
@@ -158,4 +160,4 @@ jobs:
           body: |
             # Outdated Dependencies
 
-            ${{ steps.outdated-javascript-dependencies.outputs.stdout }}
+            ${{ steps.outdated-javascript-dependencies.outputs.outdated_dependencies }}


### PR DESCRIPTION
This should fix things, maybe.

# Bug Fix

This is a bug fix for `github-actions`. It fixes an unintended side-effect of the package.

Please see the commits tab of this pull request for the description of changes.
