### PR TITLE
Use the internal alex-c-line wrapper of pnpm outdated to display the …

### DIFF
--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -134,10 +134,15 @@ jobs:
           title: "Update dependencies"
           body-path: .github/PULL_REQUEST_TEMPLATE/tooling_change.md
 
+      - name: Install alex-c-line
+        run: |
+          npm install -g alex-c-line@latest
+          alex-c-line --version
+
       - name: Get outdated JavaScript dependencies
         id: outdated-javascript-dependencies
         run: |
-          OUTDATED_DEPENDENCIES=$(pnpm outdated || true)
+          OUTDATED_DEPENDENCIES=$(alex-c-line internal outdated-dependencies)
 
           echo "outdated_dependencies=$OUTDATED_DEPENDENCIES" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
…outdated dependencies

# Bug Fix

This is a bug fix for `github-actions`. It fixes an unintended side-effect of the package.

Please see the commits tab of this pull request for the description of changes.
