### PR TITLE
Try splitting the outdated comment from the main workflow

### DIFF
--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -10,15 +10,16 @@ on:
       APP_PRIVATE_KEY:
         required: true
 
-permissions:
-  contents: write
-  pull-requests: write
-
 jobs:
   update-dependencies:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     env:
       HUSKY: 0
+    outputs:
+      pull-request-number: ${{ steps.pull-request.outputs.pull-request-number }}
 
     steps:
       - name: Checkout the repository
@@ -134,6 +135,39 @@ jobs:
           title: "Update dependencies"
           body-path: .github/PULL_REQUEST_TEMPLATE/tooling_change.md
 
+  comment-outdated:
+    runs-on: ubuntu-latest
+    needs: update-dependencies
+    permissions:
+      actions: read
+      checks: write
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Checkout pull request
+        env:
+          PULL_REQUEST_NUMBER: ${{ needs.update-dependencies.outputs.pull-request-number }}
+        run: gh pr checkout "$PULL_REQUEST_NUMBER"
+
+      - name: Use PNPM
+        uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
+        with:
+          run_install: false
+
+      - name: Use Node.js
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+        with:
+          node-version: 22
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install
+
       - name: Install alex-c-line
         run: |
           npm install -g alex-c-line@latest
@@ -150,20 +184,27 @@ jobs:
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
 
+      - name: Get alex-up-bot GitHub token
+        id: app-token
+        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
+        with:
+          app-id: ${{ github.repository == 'alextheman231/github-actions' && secrets.ALEX_UP_BOT_APP_ID || secrets.APP_ID }}
+          private-key: ${{ github.repository == 'alextheman231/github-actions' && secrets.ALEX_UP_BOT_PRIVATE_KEY || secrets.APP_PRIVATE_KEY }}
+
       - name: Find Comment
         uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad # v4.0.0
         id: find-comment
         with:
-          issue-number: ${{ steps.pull-request.outputs.pull-request-number }}
+          issue-number: ${{ needs.update-dependencies.outputs.pull-request-number }}
           comment-author: "alex-up-bot[bot]"
           body-includes: # Outdated Dependencies
 
-      - name: Comment the plan on the pull request
+      - name: Comment outdated dependencies on the pull request
         uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
         id: create-comment
         with:
           token: ${{ steps.app-token.outputs.token }}
-          issue-number: ${{ steps.pull-request.outputs.pull-request-number }}
+          issue-number: ${{ needs.update-dependencies.outputs.pull-request-number }}
           comment-id: ${{ steps.find-comment.outputs.comment-id }}
           edit-mode: replace
           body: |


### PR DESCRIPTION
This ensures a clean environment for the outdated comments, as opposed to potentially trying to get them from mutated repository state.

# Tooling Change

This is a change to the tooling of `github-actions`. It changes the internal workings of the package and should have no noticeable effect on users.

Please see the commits tab of this pull request for the description of changes.
