### PR TITLE
Add comment-outdated workflow

### DIFF
--- a/.github/workflows/_comment-outdated.yml
+++ b/.github/workflows/_comment-outdated.yml
@@ -1,0 +1,19 @@
+name: Comment outdated dependencies (internal)
+
+on:
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  comment-outdated:
+    uses: ./.github/workflows/comment-outdated.yml
+    permissions:
+      actions: read
+      checks: write
+      contents: read
+      pull-requests: write
+    with:
+      pull-request-number: ${{ github.event.pull_request.number }}
+    secrets:
+      APP_ID: ${{ secrets.ALEX_UP_BOT_APP_ID }}
+      APP_PRIVATE_KEY: ${{ secrets.ALEX_UP_BOT_PRIVATE_KEY }}

--- a/.github/workflows/comment-outdated.yml
+++ b/.github/workflows/comment-outdated.yml
@@ -1,0 +1,93 @@
+name: Comment outdated dependencies
+
+on:
+  workflow_call:
+    secrets:
+      APP_ID:
+        required: true
+      APP_PRIVATE_KEY:
+        required: true
+
+    inputs:
+      pull-request-number:
+        required: true
+        type: number
+
+jobs:
+  comment-outdated:
+    runs-on: ubuntu-latest
+    if: ${{ github.head_ref == 'alex-up-bot/update-dependencies' }}
+    permissions:
+      actions: read
+      checks: write
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Get alex-up-bot GitHub token
+        id: app-token
+        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - name: Checkout pull request
+        env:
+          PULL_REQUEST_NUMBER: ${{ inputs.pull-request-number }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: gh pr checkout "$PULL_REQUEST_NUMBER"
+
+      - name: Use PNPM
+        uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
+        with:
+          run_install: false
+
+      - name: Use Node.js
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+        with:
+          node-version: 22
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Install alex-c-line
+        run: |
+          npm install -g alex-c-line@latest
+          alex-c-line --version
+
+      - name: Get outdated JavaScript dependencies
+        id: outdated-javascript-dependencies
+        run: |
+          OUTDATED_DEPENDENCIES="$(alex-c-line internal outdated-dependencies)"
+
+          {
+            echo "outdated_dependencies<<EOF"
+            echo "$OUTDATED_DEPENDENCIES"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Find Comment
+        uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad # v4.0.0
+        id: find-comment
+        with:
+          issue-number: ${{ inputs.pull-request-number }}
+          comment-author: "alex-up-bot[bot]"
+          body-includes: # Outdated Dependencies
+
+      - name: Comment outdated dependencies on the pull request
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
+        id: create-comment
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          issue-number: ${{ inputs.pull-request-number }}
+          comment-id: ${{ steps.find-comment.outputs.comment-id }}
+          edit-mode: replace
+          body: |
+            # Outdated Dependencies
+
+            ${{ steps.outdated-javascript-dependencies.outputs.outdated_dependencies }}

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -18,8 +18,6 @@ jobs:
       pull-requests: write
     env:
       HUSKY: 0
-    outputs:
-      pull-request-number: ${{ steps.pull-request.outputs.pull-request-number }}
 
     steps:
       - name: Checkout the repository
@@ -134,81 +132,3 @@ jobs:
           base: main
           title: "Update dependencies"
           body-path: .github/PULL_REQUEST_TEMPLATE/tooling_change.md
-
-  comment-outdated:
-    runs-on: ubuntu-latest
-    needs: update-dependencies
-    permissions:
-      actions: read
-      checks: write
-      contents: read
-      pull-requests: write
-    steps:
-      - name: Checkout the repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-
-      - name: Get alex-up-bot GitHub token
-        id: app-token
-        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
-        with:
-          app-id: ${{ github.repository == 'alextheman231/github-actions' && secrets.ALEX_UP_BOT_APP_ID || secrets.APP_ID }}
-          private-key: ${{ github.repository == 'alextheman231/github-actions' && secrets.ALEX_UP_BOT_PRIVATE_KEY || secrets.APP_PRIVATE_KEY }}
-
-      - name: Checkout pull request
-        env:
-          PULL_REQUEST_NUMBER: ${{ needs.update-dependencies.outputs.pull-request-number }}
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-        run: gh pr checkout "$PULL_REQUEST_NUMBER"
-
-      - name: Use PNPM
-        uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
-        with:
-          run_install: false
-
-      - name: Use Node.js
-        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
-        with:
-          node-version: 22
-          cache: "pnpm"
-
-      - name: Install dependencies
-        run: pnpm install
-
-      - name: Install alex-c-line
-        run: |
-          npm install -g alex-c-line@latest
-          alex-c-line --version
-
-      - name: Get outdated JavaScript dependencies
-        id: outdated-javascript-dependencies
-        run: |
-          OUTDATED_DEPENDENCIES="$(alex-c-line internal outdated-dependencies)"
-
-          {
-            echo "outdated_dependencies<<EOF"
-            echo "$OUTDATED_DEPENDENCIES"
-            echo "EOF"
-          } >> "$GITHUB_OUTPUT"
-
-      - name: Find Comment
-        uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad # v4.0.0
-        id: find-comment
-        with:
-          issue-number: ${{ needs.update-dependencies.outputs.pull-request-number }}
-          comment-author: "alex-up-bot[bot]"
-          body-includes: # Outdated Dependencies
-
-      - name: Comment outdated dependencies on the pull request
-        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
-        id: create-comment
-        with:
-          token: ${{ steps.app-token.outputs.token }}
-          issue-number: ${{ needs.update-dependencies.outputs.pull-request-number }}
-          comment-id: ${{ steps.find-comment.outputs.comment-id }}
-          edit-mode: replace
-          body: |
-            # Outdated Dependencies
-
-            ${{ steps.outdated-javascript-dependencies.outputs.outdated_dependencies }}


### PR DESCRIPTION
Note that this is also following a pattern I'd like to use more going forward, where the main workflow name (no underscore in file name) is the workflow to be referenced in all repositories, and the internal workflow (underscore in file name) is what this repository uses to reference the workflow. This should alleviate the pain of inconsistent behaviour between using the workflow in context and using it as a reusable workflow, as we'd be able to use it as a reusable workflow in the repository itself and catch errors before release, at least.

# New Feature

This is a new feature for `github-actions`. It adds new functionality to the package.

Please see the commits tab of this pull request for the description of changes.
