### PR TITLE
Disable the secrets-outside-env and superflous-actions Zizmor rules

### DIFF
--- a/zizmor.yml
+++ b/zizmor.yml
@@ -1,0 +1,5 @@
+rules:
+  secrets-outside-env:
+    disable: true
+  superfluous-actions:
+    disable: true


### PR DESCRIPTION
They seems like it could be a useful rule to have, but I don't think it's super necessary for now and would require a refactor of the organisation variables. We are generally careful about passing secrets around workflows anyway, only really using them when needed, so I think it is fine to disable for now.

# Tooling Change

This is a change to the tooling of `github-actions`. It changes the internal workings of the package and should have no noticeable effect on users.

Please see the commits tab of this pull request for the description of changes.
