### PR TITLE
Add a step to build the configuration files when publishing to GitHub…

### DIFF
--- a/.github/workflows/publish-github-pages.yml
+++ b/.github/workflows/publish-github-pages.yml
@@ -11,6 +11,11 @@ on:
         description: The path to the directory to publish. It must have an index.html file inside of it.
         required: true
         type: string
+      build-configs:
+        description: Build the configuration files that may be needed to generate the documentation.
+        required: false
+        default: false
+        type: boolean
 
 jobs:
   publish-github-pages:
@@ -40,6 +45,10 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install
+
+      - name: Build the configs
+        if: ${{ inputs.build-configs == true }}
+        run: pnpm run build-configs
 
       - name: Create the feature docs
         run: pnpm run create-feature-docs

--- a/docs/releases/v11/v11.1/v11.1.0.md
+++ b/docs/releases/v11/v11.1/v11.1.0.md
@@ -1,0 +1,17 @@
+# v11.1.0 (Minor Release)
+
+<!-- alex-c-line-release-status-start -->
+**Status**: In progress
+<!-- alex-c-line-release-status-end -->
+
+<!-- alex-c-line-release-summary-start -->
+This is a new minor release of the `github-actions` package. It introduces new features and other backwards-compatible changes that should require little to no refactoring. Please read the description of changes below.
+<!-- alex-c-line-release-summary-end -->
+
+## Description of Changes
+
+<!-- user-editable-section-start -->
+- Add a step to build the configs if needed in `publish-github-pages`.
+    - The TypeDoc configuration in utility needs to be built to JavaScript before we can generate the feature docs.
+    - The expected command this step would run is `pnpm run build-configs`.
+<!-- user-editable-section-end -->


### PR DESCRIPTION
… Pages

It may be needed sometimes, most notably in the case of my utility package.

# New Feature

This is a new feature for `github-actions`. It adds new functionality to the package.

Please see the commits tab of this pull request for the description of changes.
