### PR TITLE
Add end to end node package ci

### DIFF
--- a/.github/workflows/end-to-end-node-package-ci.yml
+++ b/.github/workflows/end-to-end-node-package-ci.yml
@@ -15,7 +15,10 @@ permissions:
 jobs:
   end-to-end-ci-steps:
     if: ${{ github.head_ref != 'alex-up-bot/change-major-version' && github.head_ref != 'alex-up-bot/change-minor-version' && github.head_ref != 'alex-up-bot/change-patch-version' }}
-    runs-on: ${{ fromJson(inputs.os) }}
+    strategy:
+      matrix:
+        os: ${{ fromJson(inputs.os) }}
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout the repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/docs/releases/v11/v11.2/v11.2.1.md
+++ b/docs/releases/v11/v11.2/v11.2.1.md
@@ -1,0 +1,16 @@
+# v11.2.1 (Patch Release)
+
+<!-- alex-c-line-release-status-start -->
+**Status**: In progress
+<!-- alex-c-line-release-status-end -->
+
+<!-- alex-c-line-release-summary-start -->
+This is a new patch release of the `github-actions` package. It includes small, non-breaking changes and should require no refactoring. Please read the description of changes below.
+<!-- alex-c-line-release-summary-end -->
+
+## Description of Changes
+
+<!-- user-editable-section-start -->
+- Use matrix strategy correctly in `end-to-end-node-package-ci`
+    - Otherwise it freezes indefinitely trying to apply the JSON-ified list of operating systems.
+<!-- user-editable-section-end -->


### PR DESCRIPTION
# Bug Fix

This is a bug fix for `github-actions`. It fixes an unintended side-effect of the package.

Please see the commits tab of this pull request for the description of changes.
