### PR TITLE
Release note v11.2.2

### DIFF
--- a/docs/releases/v11/v11.2/v11.2.2.md
+++ b/docs/releases/v11/v11.2/v11.2.2.md
@@ -1,0 +1,18 @@
+# v11.2.2 (Patch Release)
+
+<!-- alex-c-line-release-status-start -->
+**Status**: In progress
+<!-- alex-c-line-release-status-end -->
+
+<!-- alex-c-line-release-summary-start -->
+This is a new patch release of the `github-actions` package. It includes small, non-breaking changes and should require no refactoring. Please read the description of changes below.
+<!-- alex-c-line-release-summary-end -->
+
+## Description of Changes
+
+<!-- user-editable-section-start -->
+- Update all composite actions and reusable workflows.
+    - This includes using `pnpm/action-setup` v6, which also supports `pnpm` v11.
+- Use `npm` for the global `actions-up` install in `update-dependencies` workflow.
+    - The `pnpm` global install does not work with v11 for whatever reason.
+<!-- user-editable-section-end -->


### PR DESCRIPTION
# Documentation Change

This is a change to the documentation of `github-actions`. It changes the way that information about the package is presented to users.

Please see the commits tab of this pull request for the description of changes.
