### PR TITLE
Workflow permission

### DIFF
--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -80,6 +80,7 @@ jobs:
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           permission-contents: write
           permission-pull-requests: write
+          permission-actions: write
 
       - name: Setup GitHub user
         run: |

--- a/docs/releases/v11/v11.2/v11.2.4.md
+++ b/docs/releases/v11/v11.2/v11.2.4.md
@@ -1,0 +1,20 @@
+# v11.2.4 (Patch Release)
+
+<!-- alex-c-line-release-status-start -->
+**Status**: In progress
+<!-- alex-c-line-release-status-end -->
+
+<!-- alex-c-line-release-summary-start -->
+This is a new patch release of the `github-actions` package. It includes small, non-breaking changes and should require no refactoring. Please read the description of changes below.
+<!-- alex-c-line-release-summary-end -->
+
+## Description of Changes
+
+<!-- user-editable-section-start -->
+- Give the `update-dependencies` generated `alex-up-bot` app token write access to actions.
+    - That workflow needs it in order to update the composite actions in the workflow files.
+
+## Additional Notes
+
+- Yeah, I had a feeling something somewhere was gonna break, and here we are...
+<!-- user-editable-section-end -->


### PR DESCRIPTION
# Bug Fix

This is a bug fix for `github-actions`. It fixes an unintended side-effect of the package.

Please see the commits tab of this pull request for the description of changes.
